### PR TITLE
Parse plural oGroups option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,8 @@ build/popeye: image build
 release: build/popeye
 	docker build --tag $(IMAGE_NAME) .
 
+check: release
+	docker run --rm --env-file .env \
+	  codeclimate/popeye --group ssh --group sshbastiononly
+
 .PHONY: image

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ release: build/popeye
 
 check: release
 	docker run --rm --env-file .env \
-	  codeclimate/popeye --group ssh --group sshbastiononly
+	  codeclimate/popeye --group ssh --user pat@codeclimate.com
 
 .PHONY: image

--- a/src/Popeye/CLI.hs
+++ b/src/Popeye/CLI.hs
@@ -14,7 +14,7 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
 data Options = Options
-    { oGroup :: Group
+    { oGroups :: [Group]
     , oDebug :: Bool
     }
 
@@ -27,7 +27,7 @@ run = do
     env <- set envLogger lgr <$> newEnv NorthVirginia Discover
 
     runResourceT . runAWS env $
-        (mapM_ outputUser =<< getUsers (oGroup opts))
+        (mapM_ outputUser =<< getUsers (oGroups opts))
 
 outputUser :: MonadIO m => User -> m ()
 outputUser u = do
@@ -42,7 +42,7 @@ getOptions = execParser $ info (helper <*> parseOptions)
 
 parseOptions :: Parser Options
 parseOptions = Options
-    <$> (Group . T.pack <$> strOption
+    <$> some (Group . T.pack <$> strOption
         (  short 'g'
         <> long "group"
         <> metavar "GROUP"

--- a/src/Popeye/Users.hs
+++ b/src/Popeye/Users.hs
@@ -5,10 +5,11 @@ module Popeye.Users
     , UserPublicKey(..)
     , Group(..)
     , getUsers
+    , getUser
     ) where
 
 import Control.Lens (set, view)
-import Control.Monad (forM, mfilter)
+import Control.Monad (mfilter)
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import Network.AWS
@@ -29,16 +30,16 @@ data User = User
     }
 
 getUsers :: [Group] -> AWS [User]
-getUsers gs = do
-    uns <- concat <$> mapM getUserNames gs
+getUsers gs = mapM getUser =<< concat <$> mapM getUserNames gs
 
-    forM uns $ \un -> do
-        pks <- mapM (getPublicKeyContent un) =<< getPublicKeyIds un
+getUser :: UserName -> AWS User
+getUser un = do
+    pks <- mapM (getPublicKeyContent un) =<< getPublicKeyIds un
 
-        return User
-            { userName = un
-            , userPublicKeys = catMaybes pks
-            }
+    return User
+        { userName = un
+        , userPublicKeys = catMaybes pks
+        }
 
 getUserNames :: Group -> AWS [UserName]
 getUserNames g = do

--- a/src/Popeye/Users.hs
+++ b/src/Popeye/Users.hs
@@ -28,9 +28,9 @@ data User = User
     , userPublicKeys :: [UserPublicKey]
     }
 
-getUsers :: Group -> AWS [User]
-getUsers g = do
-    uns <- getUserNames g
+getUsers :: [Group] -> AWS [User]
+getUsers gs = do
+    uns <- concat <$> mapM getUserNames gs
 
     forM uns $ \un -> do
         pks <- mapM (getPublicKeyContent un) =<< getPublicKeyIds un

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-4.2
+resolver: lts-6.11
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
We'll use this to allow separate groups for adding keys to specific servers,
instead of a single group to mean "everywhere".

/cc @codeclimate/review